### PR TITLE
[MHT-11] Feature/emote anvil and sign support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.vscode
 out
 target

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 in plugin config.yml:
 ```yml
 override:
-    words:
-        ":discord_emoji:"
-    replacements:
-        ":discord_emoji:": "\uE002" # replace with ur unicode symbole
+    ":discord_emoji:": "\uE002" # replace with ur unicode symbole
 ```
-### Texture pack side
+
+### Texture pack sidesi
 Use a additional texture pack to replace Unicode emojis by images <br>
-`${texturepack_folder}/assets/minecraft/font/include/default.json`
+```bash
+${texturepack_folder}/assets/minecraft/font/include/default.json
+```
 ```json
 {
     "providers":[
@@ -28,5 +28,7 @@ Use a additional texture pack to replace Unicode emojis by images <br>
     ]
 }
 ```
-`${texturepack_folder}/assets/minecraft/textures/font/custom/emojis/`
+```bash
+${texturepack_folder}/assets/minecraft/textures/font/custom/emojis/
+```
 ![](https://github.com/MignonPetitXelow/Momento/blob/main/.assets/exa2.png)

--- a/src/main/java/org/momento/Events/AnvilRename.java
+++ b/src/main/java/org/momento/Events/AnvilRename.java
@@ -1,0 +1,5 @@
+package org.momento.Events;
+
+public class AnvilRename {
+    
+}

--- a/src/main/java/org/momento/Events/AnvilRename.java
+++ b/src/main/java/org/momento/Events/AnvilRename.java
@@ -1,5 +1,22 @@
 package org.momento.Events;
 
-public class AnvilRename {
-    
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.momento.Features.EmojiSystem;
+
+public class AnvilRename implements Listener{
+    @EventHandler
+    public void onAnvilRename(InventoryClickEvent event) {
+        if(event.getRawSlot() != 2) return;
+
+        ItemStack renamedItem = event.getCurrentItem();
+        if( renamedItem == null || !renamedItem.hasItemMeta()) return;
+
+        ItemMeta meta = renamedItem.getItemMeta();
+        meta.setDisplayName(EmojiSystem.EmojiStringReplacer(meta.getDisplayName()));
+        renamedItem.setItemMeta(meta);
+    }
 }

--- a/src/main/java/org/momento/Events/ChatSystem.java
+++ b/src/main/java/org/momento/Events/ChatSystem.java
@@ -11,7 +11,6 @@ public class ChatSystem implements Listener
     @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) 
     {
-        String message = event.getMessage();
-        event.setMessage(EmojiSystem.EmojiStringReplacer(message));
+        event.setMessage(EmojiSystem.EmojiStringReplacer(event.getMessage()));
     }
 }

--- a/src/main/java/org/momento/Events/ChatSystem.java
+++ b/src/main/java/org/momento/Events/ChatSystem.java
@@ -3,22 +3,15 @@ package org.momento.Events;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.momento.Momento;
-import java.util.List;
+import org.momento.Features.EmojiSystem;
+
 
 public class ChatSystem implements Listener
 {
     @EventHandler
-    public void onPlayerChat(AsyncPlayerChatEvent event) {
+    public void onPlayerChat(AsyncPlayerChatEvent event) 
+    {
         String message = event.getMessage();
-        List<String> overrideWords = Momento.config.getStringList("override.words");
-
-        for (String word : overrideWords)
-            if (message.contains(word))
-            {
-                String replacement = Momento.config.getString("override.replacements." + word);
-                if (replacement != null) message = message.replaceAll("(?i)" + word, replacement);
-            }
-        event.setMessage(message);
+        event.setMessage(EmojiSystem.EmojiStringReplacer(message));
     }
 }

--- a/src/main/java/org/momento/Events/SignEvent.java
+++ b/src/main/java/org/momento/Events/SignEvent.java
@@ -1,0 +1,18 @@
+package org.momento.Events;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.SignChangeEvent;
+import org.momento.Features.EmojiSystem;
+
+public class SignEvent implements Listener {
+    
+    @EventHandler
+    public void onSignChange(SignChangeEvent event) {
+        String[] lines = event.getLines();
+        if(lines == null || lines.length == 0) return;
+        
+        for(int i = 0; i < lines.length; i++)
+            event.setLine(i, EmojiSystem.EmojiStringReplacer(lines[i]));
+    }
+}

--- a/src/main/java/org/momento/Features/EmojiSystem.java
+++ b/src/main/java/org/momento/Features/EmojiSystem.java
@@ -1,0 +1,19 @@
+package org.momento.Features;
+
+import org.momento.Momento;
+import java.util.Map;
+
+public class EmojiSystem {
+    public static String EmojiStringReplacer(String message) {
+        Map<String, Object> overrideMap = Momento.config.getConfigurationSection("override").getValues(false);
+
+        for (Map.Entry<String, Object> entry : overrideMap.entrySet()) 
+        {
+            String word = entry.getKey();
+            String replacement = entry.getValue().toString();
+            if (message.contains(word))
+                message = message.replaceAll("(?i)" + word, replacement);
+        }
+        return message;
+    }
+}

--- a/src/main/java/org/momento/Features/EmojiSystem.java
+++ b/src/main/java/org/momento/Features/EmojiSystem.java
@@ -12,7 +12,7 @@ public class EmojiSystem {
             String word = entry.getKey();
             String replacement = entry.getValue().toString();
             if (message.contains(word))
-                message = message.replaceAll("(?i)" + word, replacement);
+                message = message.replaceAll("(?i)" + word, "§r"+replacement);
         }
         return message;
     }

--- a/src/main/java/org/momento/Features/EmojiSystem.java
+++ b/src/main/java/org/momento/Features/EmojiSystem.java
@@ -12,7 +12,7 @@ public class EmojiSystem {
             String word = entry.getKey();
             String replacement = entry.getValue().toString();
             if (message.contains(word))
-                message = message.replaceAll("(?i)" + word, "§r"+replacement);
+                message = message.replaceAll("(?i)" + word, "§f"+replacement+"§r");
         }
         return message;
     }

--- a/src/main/java/org/momento/Momento.java
+++ b/src/main/java/org/momento/Momento.java
@@ -2,11 +2,9 @@ package org.momento;
 
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.*;
+import org.momento.Events.*;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.momento.Events.AnvilRename;
-import org.momento.Events.ChatSystem;
 
 public final class Momento extends JavaPlugin {
 
@@ -22,6 +20,7 @@ public final class Momento extends JavaPlugin {
 
         pluginManager.registerEvents(new ChatSystem(), this);
         pluginManager.registerEvents(new AnvilRename(), this);
+        pluginManager.registerEvents(new SignEvent(), this);
     }
 
     @Override

--- a/src/main/java/org/momento/Momento.java
+++ b/src/main/java/org/momento/Momento.java
@@ -5,6 +5,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.momento.Events.AnvilRename;
 import org.momento.Events.ChatSystem;
 
 public final class Momento extends JavaPlugin {
@@ -20,6 +21,7 @@ public final class Momento extends JavaPlugin {
         PluginManager pluginManager = Bukkit.getPluginManager();
 
         pluginManager.registerEvents(new ChatSystem(), this);
+        pluginManager.registerEvents(new AnvilRename(), this);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,24 +1,9 @@
 override:
-  words:
-    # emojis
-    - ":astolfo_tea:"
-    - ":zerotwo_heartlove:"
-    - ":Worry:"
-    - ":monikaheart:"
-    - ":yanfeiowo:"
-    - ":ohhhh:"
-    # stickers
-    - "eltysus"
-    - "ohnourip"
-  replacements:
-    #emojis
-    ":astolfo_tea:": "\uE002"
-    ":zerotwo_heartlove:": "\uE003"
-    ":Worry:": "\uE004"
-    ":monikaheart:": "\uE005"
-    ":yanfeiowo:": "\uE006"
-    ":ohhhh:": "\uE007"
-    # stickers
-    "eltysus": "\n\n\n\n\n\n\uE101\n\n\n" # tricky but it work lmao
-    "ohnourip": "\n\n\n\n\n\n\uE102\n"
-
+  ":astolfo_tea:": "\uE002"
+  ":zerotwo_heartlove:": "\uE003"
+  ":Worry:": "\uE004"
+  ":monikaheart:": "\uE005"
+  ":yanfeiowo:": "\uE006"
+  ":ohhhh:": "\uE007"
+  "eltysus": "\n\n\n\n\n\n\uE101\n\n\n" # tricky but it work lmao
+  "ohnourip": "\n\n\n\n\n\n\uE102\n"


### PR DESCRIPTION
# 🇫🇷  Contenu majeur:

- Ajouter la possibilité d'inclure des emojis dans le nom des objets à l'aide de l'enclume et d'afficher des emojis sur des panneaux.
- Ajoute la fonction EmojiStringReplacer(String) pour uniformiser tous les cas possibles d'utilisation.

## Contenu mineur:

Modifier la gestion de la configuration des emojis/stickers en utilisant une seule liste au lieu de deux.


# 🇬🇧 Major content:

- Add the ability to include emojis in the names of items using the anvil and to display emojis on panels.
- Add the `EmojiStringReplacer(String)` function to standardize across all use cases

## Minor content:

Change the way emojis/stickers configuration is handled by using a single list instead of two.

# Images:
![](https://cdn.discordapp.com/attachments/1096801285027659808/1230929557830500392/2024-04-19_18.14.05.png?ex=66351b7c&is=6622a67c&hm=e76d782d0e47ac00095816601a2e7b4d5e724fe34f5baf64400205f74d2164fd&)